### PR TITLE
fix: resolve annotations with get_type_hints in attach_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v0.9.2 - 2026-03-19
+- Fixed `attach_settings` crashing with `NameError` when the decorated function
+  uses string annotations (i.e. `from __future__ import annotations` or Python 3.14+)
+- `attach_settings` now resolves annotations with `typing.get_type_hints()` before
+  comparing them against `settings_model` and `SettingsManager`, so string and
+  evaluated annotations are handled identically
+
+
 ## v0.9.1 - 2026-03-12
 - Fixed issue with binding using SecretStr settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typerdrive"
-version = "0.9.1"
+version = "0.9.2"
 description = "Develop API-Connected Typer Apps at Lightspeed"
 authors = [
     {name = "Tucker Beck", email ="tucker.beck@gmail.com"},

--- a/src/typerdrive/settings/attach.py
+++ b/src/typerdrive/settings/attach.py
@@ -4,7 +4,7 @@ Provide a decorator that attaches the `typerdrive` settings to a `typer` command
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
 
 import typer
 from pydantic import BaseModel
@@ -88,11 +88,12 @@ def attach_settings(
     def _decorate(func: ContextFunction[P, T]) -> ContextFunction[P, T]:
         manager_param_key: str | None = None
         settings_param_key: str | None = None
+        resolved = get_type_hints(func)
         for key in func.__annotations__.keys():
-            if func.__annotations__[key] is settings_model:
+            if resolved.get(key) is settings_model:
                 func.__annotations__[key] = Annotated[settings_model | None, CloakingDevice]  # ty: ignore[invalid-type-form]
                 settings_param_key = key
-            elif func.__annotations__[key] is SettingsManager:
+            elif resolved.get(key) is SettingsManager:
                 func.__annotations__[key] = Annotated[SettingsManager | None, CloakingDevice]
                 manager_param_key = key
 

--- a/tests/unit/settings/string_annotation_module.py
+++ b/tests/unit/settings/string_annotation_module.py
@@ -1,0 +1,49 @@
+# This module intentionally uses `from __future__ import annotations` so that
+# all annotations are stored as strings rather than evaluated types.  This
+# replicates the annotation-evaluation behaviour introduced in Python 3.14
+# (PEP 649) and lets us test `attach_settings` against string annotations on
+# any supported Python version.
+from __future__ import annotations
+
+import typer
+from typerdrive.settings.attach import attach_settings, get_settings
+from typerdrive.settings.manager import SettingsManager
+
+from tests.unit.settings.models import DefaultSettingsModel
+
+
+def make_string_annotated_cli() -> typer.Typer:
+    """
+    Return a Typer app whose command functions have string annotations.
+
+    Because this module uses `from __future__ import annotations`, every type
+    annotation in every function defined here is stored as a plain string in
+    `__annotations__`.  Passing such a function to `attach_settings` previously
+    caused a `NameError` because the decorator compared raw annotation strings
+    against type objects using `is`.
+    """
+    cli = typer.Typer()
+
+    @cli.command()
+    @attach_settings(DefaultSettingsModel)
+    def noop(ctx: typer.Context, stuff: DefaultSettingsModel) -> None:
+        settings = get_settings(ctx, DefaultSettingsModel)
+        assert settings.name == "jawa"
+        print("Passed!")
+
+    return cli
+
+
+def make_string_annotated_manager_cli() -> typer.Typer:
+    """
+    Return a Typer app whose command uses a `SettingsManager` parameter with string annotations.
+    """
+    cli = typer.Typer()
+
+    @cli.command()
+    @attach_settings(DefaultSettingsModel)
+    def noop(ctx: typer.Context, mgr: SettingsManager) -> None:
+        assert isinstance(mgr, SettingsManager)
+        print("Passed!")
+
+    return cli

--- a/tests/unit/settings/test_attach.py
+++ b/tests/unit/settings/test_attach.py
@@ -13,6 +13,7 @@ from typerdrive.settings.manager import SettingsManager
 
 from tests.unit.helpers import match_help, match_output
 from tests.unit.settings.models import DefaultSettingsModel, RequiredFieldsModel
+from tests.unit.settings.string_annotation_module import make_string_annotated_cli, make_string_annotated_manager_cli
 
 
 class TestAttachSettings:
@@ -386,5 +387,40 @@ class TestGetManager:
             exception_type=SettingsError,
             exception_pattern="Item in user context at `settings_manager` was not a SettingsManager",
             exit_code=1,
+            prog_name="test",
+        )
+
+
+class TestStringAnnotations:
+    """
+    Verify that `attach_settings` works correctly when the decorated function
+    stores its annotations as strings rather than resolved types.
+
+    This happens in any module that uses `from __future__ import annotations`
+    (all Python versions) and is the default behaviour in Python 3.14+ (PEP 649).
+    Previously, the decorator compared raw `__annotations__` values against type
+    objects using `is`, which always failed for string annotations and could raise
+    a `NameError` when Python's machinery tried to resolve the strings.
+    """
+
+    def test_settings_parameter_injected_with_string_annotations(self):
+        """Settings parameter is injected correctly when annotations are strings."""
+        cli = make_string_annotated_cli()
+
+        match_output(
+            cli,
+            expected_pattern=["Passed"],
+            exit_code=0,
+            prog_name="test",
+        )
+
+    def test_manager_parameter_injected_with_string_annotations(self):
+        """SettingsManager parameter is injected correctly when annotations are strings."""
+        cli = make_string_annotated_manager_cli()
+
+        match_output(
+            cli,
+            expected_pattern=["Passed"],
+            exit_code=0,
             prog_name="test",
         )


### PR DESCRIPTION
## Summary

- Fixes a `NameError` crash when `attach_settings` decorates a function whose annotations are stored as strings — either because the module uses `from __future__ import annotations` or because Python 3.14+ (PEP 649) stores annotations as strings by default
- `attach_settings` now calls `typing.get_type_hints()` to resolve annotations before comparing them against `settings_model` / `SettingsManager`, so string and evaluated annotations are handled identically
- Mutations to `func.__annotations__` (the cloaking device injection that hides parameters from typer's help output) are preserved as-is

## Root cause

The previous implementation read `func.__annotations__` directly:

```python
for key in func.__annotations__.keys():
    if func.__annotations__[key] is settings_model:
```

When annotations are strings (e.g. `"CrolTrollSettings"` instead of the class), the `is` comparison always fails silently — settings and manager parameters are never cloaked — and Python 3.14's annotation evaluation machinery can raise `NameError: name 'Context' is not defined` when it tries to resolve the string `"Context"` in the wrapper's scope.

## Changes

- `src/typerdrive/settings/attach.py`: resolve via `get_type_hints()` before comparing
- `tests/unit/settings/string_annotation_module.py`: new helper module defined under `from __future__ import annotations` to replicate Python 3.14 string-annotation behaviour on all supported versions
- `tests/unit/settings/test_attach.py`: added `TestStringAnnotations` with two tests
- `pyproject.toml`: bumped to `0.9.2`
- `CHANGELOG.md`: added entry for `v0.9.2`