### PR TITLE
fix: resolve string-annotation NameError in all attach_* decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v0.9.5 - 2026-05-04
+- Fixed `NameError` in `attach_cache`, `attach_client`, `attach_files`, `attach_logging`
+  - Caused by string annotations (`from __future__ import annotations` or Python 3.14+)
+  - Now uses `get_type_hints()` instead of `func.__annotations__`
+  - Consistent with existing fix in `attach_settings`
+- Fixed type-checker error in `attach_settings` exposed by the annotation resolution refactor
+  - Added `# type: ignore[invalid-type-form]` where `settings_model` is used in a runtime `Annotated` expression
+
+
 ## v0.9.4 - 2026-05-02
 - Fixed the bug in show logs where characters in the output were interpreted by rich as markup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typerdrive"
-version = "0.9.4"
+version = "0.9.5"
 description = "Develop API-Connected Typer Apps at Lightspeed"
 authors = [
     {name = "Tucker Beck", email ="tucker.beck@gmail.com"},

--- a/src/typerdrive/cache/attach.py
+++ b/src/typerdrive/cache/attach.py
@@ -4,7 +4,7 @@ Provide a decorator that attaches the `typerdrive` cache to a `typer` command fu
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
 
 import typer
 
@@ -42,8 +42,9 @@ def attach_cache(show: bool = False) -> Callable[[ContextFunction[P, T]], Contex
 
     def _decorate(func: ContextFunction[P, T]) -> ContextFunction[P, T]:
         manager_param_key: str | None = None
-        for key in func.__annotations__.keys():
-            if func.__annotations__[key] is CacheManager:
+        resolved = get_type_hints(func)
+        for key, hint in resolved.items():
+            if hint is CacheManager:
                 func.__annotations__[key] = Annotated[CacheManager | None, CloakingDevice]
                 manager_param_key = key
 

--- a/src/typerdrive/client/attach.py
+++ b/src/typerdrive/client/attach.py
@@ -4,7 +4,7 @@ Provide a decorator that attaches `TyperdriveClient` instances to a `typer` comm
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
 
 import typer
 from pydantic import BaseModel
@@ -57,13 +57,13 @@ def attach_client(**client_urls_or_settings_keys: str) -> Callable[[ContextFunct
     def _decorate(func: ContextFunction[P, T]) -> ContextFunction[P, T]:
         manager_param_key: str | None = None
         client_param_keys: list[str] = []
-        for key in func.__annotations__.keys():
-            if func.__annotations__[key] is TyperdriveClient:
+        resolved = get_type_hints(func)
+        for key, hint in resolved.items():
+            if hint is TyperdriveClient:
                 if key in client_urls_or_settings_keys:
                     func.__annotations__[key] = Annotated[TyperdriveClient | None, CloakingDevice]
                     client_param_keys.append(key)
-
-            elif func.__annotations__[key] is ClientManager:
+            elif hint is ClientManager:
                 func.__annotations__[key] = Annotated[ClientManager | None, CloakingDevice]
                 manager_param_key = key
 

--- a/src/typerdrive/files/attach.py
+++ b/src/typerdrive/files/attach.py
@@ -4,7 +4,7 @@ Provide a decorator that attaches the `typerdrive` files to a `typer` command fu
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
 
 import typer
 
@@ -43,8 +43,9 @@ def attach_files(show: bool = False) -> Callable[[ContextFunction[P, T]], Contex
 
     def _decorate(func: ContextFunction[P, T]) -> ContextFunction[P, T]:
         manager_param_key: str | None = None
-        for key in func.__annotations__.keys():
-            if func.__annotations__[key] is FilesManager:
+        resolved = get_type_hints(func)
+        for key, hint in resolved.items():
+            if hint is FilesManager:
                 func.__annotations__[key] = Annotated[FilesManager | None, CloakingDevice]
                 manager_param_key = key
 

--- a/src/typerdrive/logging/attach.py
+++ b/src/typerdrive/logging/attach.py
@@ -4,7 +4,7 @@ Provide a decorator that attaches logging functionality to a `typer` command fun
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Annotated, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
 
 import typer
 from loguru import logger
@@ -43,8 +43,9 @@ def attach_logging(verbose: bool = False) -> Callable[[ContextFunction[P, T]], C
 
     def _decorate(func: ContextFunction[P, T]) -> ContextFunction[P, T]:
         manager_param_key: str | None = None
-        for key in func.__annotations__.keys():
-            if func.__annotations__[key] is LoggingManager:
+        resolved = get_type_hints(func)
+        for key, hint in resolved.items():
+            if hint is LoggingManager:
                 func.__annotations__[key] = Annotated[LoggingManager | None, CloakingDevice]
                 manager_param_key = key
 

--- a/src/typerdrive/settings/attach.py
+++ b/src/typerdrive/settings/attach.py
@@ -89,11 +89,11 @@ def attach_settings(
         manager_param_key: str | None = None
         settings_param_key: str | None = None
         resolved = get_type_hints(func)
-        for key in func.__annotations__.keys():
-            if resolved.get(key) is settings_model:
-                func.__annotations__[key] = Annotated[settings_model | None, CloakingDevice]
+        for key, hint in resolved.items():
+            if hint is settings_model:
+                func.__annotations__[key] = Annotated[settings_model | None, CloakingDevice]  # type: ignore[invalid-type-form]
                 settings_param_key = key
-            elif resolved.get(key) is SettingsManager:
+            elif hint is SettingsManager:
                 func.__annotations__[key] = Annotated[SettingsManager | None, CloakingDevice]
                 manager_param_key = key
 

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "typerdrive"
-version = "0.9.4"
+version = "0.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
- Switch from `func.__annotations__` to `typing.get_type_hints()` in `attach_cache`, `attach_client`, `attach_files`, and `attach_logging`
- Ensures string annotations (from `from __future__ import annotations` or Python 3.14+) are evaluated before comparison
- Consistent with the fix already applied to `attach_settings`
- Suppress `invalid-type-form` type-checker error in `attach_settings` where `settings_model` is used in a runtime `Annotated` expression
- Bumps version to 0.9.5