### PR TITLE
fix: replace wrapper.__annotations__ with pre-resolved dict to preven…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v0.9.7 - 2026-05-05
+- Fixed `NameError: name 'Context' is not defined` crash on Python 3.14+ when using
+  any `attach_*` decorator
+  - Root cause: Python 3.14 `inspect.signature()` on a plain function bypasses
+    `__signature__` and calls `get_annotations()`, which triggers the lazy
+    `__annotate__` closure — evaluated in the wrong scope where `Context` is not
+    defined
+  - Fix: `SignatureRewriter.apply()` now also replaces `wrapper.__annotations__` with
+    a pre-resolved dict matching the rewritten signature, preventing lazy evaluation
+
 ## v0.9.6 - 2026-05-04
 - Introduced `SignatureRewriter.apply(wrapper)` method to encapsulate `__signature__`
   stamping in one place, replacing direct `wrapper.__signature__ = rewriter.build()`
   calls in all five `attach_*` decorators
-- Uses `setattr` internally so type checkers (`ty`, mypy) never see the assignment on
-  a wrapped callable type — eliminates false-positive `unresolved-attribute` errors for
-  both library internals and downstream consumers
+- Uses `setattr` for `__signature__` so type checkers (`ty`, mypy) never see the
+  assignment on a wrapped callable type — eliminates false-positive
+  `unresolved-attribute` errors for both library internals and downstream consumers
 - Removed unused `inspect.Parameter` import from `tests/unit/test_signature.py`
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typerdrive"
-version = "0.9.6"
+version = "0.9.7"
 description = "Develop API-Connected Typer Apps at Lightspeed"
 authors = [
     {name = "Tucker Beck", email ="tucker.beck@gmail.com"},

--- a/src/typerdrive/signature.py
+++ b/src/typerdrive/signature.py
@@ -49,7 +49,20 @@ class SignatureRewriter:
         """
         Stamp the rewritten `Signature` onto the wrapper function.
 
-        Uses `setattr` to assign `__signature__`, which is a well-known but
-        dynamically-set attribute not declared in stub types for wrapped callables.
+        Sets `__signature__` so introspection tools see the rewritten parameters,
+        then replaces `__annotations__` with an eagerly-evaluated dict that matches
+        the rewritten signature exactly.
+
+        On Python 3.14+, `inspect.signature()` on a plain function bypasses
+        `__signature__` and calls `get_annotations()`, which triggers the lazy
+        `__annotate__` closure — which references names (e.g. `Context`) that are
+        not in scope at evaluation time. Replacing `__annotations__` with a plain
+        pre-resolved dict prevents that evaluation entirely.
         """
-        setattr(wrapper, "__signature__", self.build())
+        sig = self.build()
+        setattr(wrapper, "__signature__", sig)
+        wrapper.__annotations__ = {
+            name: p.annotation
+            for name, p in sig.parameters.items()
+            if p.annotation is not p.empty
+        }

--- a/tests/unit/test_signature.py
+++ b/tests/unit/test_signature.py
@@ -2,6 +2,7 @@
 Tests for SignatureRewriter.
 """
 
+from functools import wraps
 from inspect import signature
 from typing import Annotated
 
@@ -96,12 +97,10 @@ class TestSignatureRewriter:
         inner_rewriter = SignatureRewriter(func)
         inner_rewriter.cloak("inner", cloaked_inner)
 
-        from functools import wraps
-
         @wraps(func)
         def inner_wrapper(*args, **kwargs): ...
 
-        inner_wrapper.__signature__ = inner_rewriter.build()  # type: ignore[attr-defined]
+        inner_rewriter.apply(inner_wrapper)
 
         # Outer decorator wraps the inner wrapper, only cloaks 'outer'
         cloaked_outer = Annotated[Outer | None, CloakingDevice]
@@ -119,3 +118,80 @@ class TestSignatureRewriter:
 
         rewriter = SignatureRewriter(func)
         assert rewriter.hints["name"] == Annotated[str, opt]
+
+
+class TestSignatureRewriterApply:
+    def test_apply__sets_signature_on_wrapper(self):
+        class Sentinel: ...
+
+        def func(ctx: typer.Context, mgr: Sentinel) -> None: ...
+
+        cloaked = Annotated[Sentinel | None, CloakingDevice]
+        rewriter = SignatureRewriter(func)
+        rewriter.cloak("mgr", cloaked)
+
+        @wraps(func)
+        def wrapper(ctx: typer.Context, *args, **kwargs): ...
+
+        rewriter.apply(wrapper)
+
+        sig = signature(wrapper)
+        assert sig.parameters["mgr"].annotation == cloaked
+
+    def test_apply__annotations_is_plain_dict(self):
+        """__annotations__ must be a plain resolved dict, not a lazy __annotate__ closure."""
+        def func(ctx: typer.Context, name: str) -> None: ...
+
+        rewriter = SignatureRewriter(func)
+
+        @wraps(func)
+        def wrapper(ctx: typer.Context, *args, **kwargs): ...
+
+        rewriter.apply(wrapper)
+
+        assert isinstance(wrapper.__annotations__, dict)
+        assert wrapper.__annotations__ == {"ctx": typer.Context, "name": str}
+
+    def test_apply__annotations_reflects_overrides(self):
+        class Sentinel: ...
+
+        def func(ctx: typer.Context, mgr: Sentinel) -> None: ...
+
+        cloaked = Annotated[Sentinel | None, CloakingDevice]
+        rewriter = SignatureRewriter(func)
+        rewriter.cloak("mgr", cloaked)
+
+        @wraps(func)
+        def wrapper(ctx: typer.Context, *args, **kwargs): ...
+
+        rewriter.apply(wrapper)
+
+        assert wrapper.__annotations__["mgr"] == cloaked
+        assert wrapper.__annotations__["ctx"] is typer.Context
+
+    def test_apply__survives_poisoned_annotate(self):
+        """
+        Simulates Python 3.14 behavior: the wrapper has a lazy __annotate__ that
+        raises NameError (as happens when a decorator-scope name like `Context`
+        is not available at evaluation time). After apply(), inspect.signature()
+        must succeed without triggering __annotate__.
+        """
+        def func(ctx: typer.Context, name: str) -> None: ...
+
+        rewriter = SignatureRewriter(func)
+
+        @wraps(func)
+        def wrapper(ctx: typer.Context, *args, **kwargs): ...
+
+        # Poison __annotate__ to simulate the Python 3.14 NameError
+        def bad_annotate(format):
+            raise NameError("name 'Context' is not defined")
+
+        wrapper.__annotate__ = bad_annotate  # type: ignore[attr-defined]
+
+        rewriter.apply(wrapper)
+
+        # inspect.signature() must not raise, even with the poisoned __annotate__
+        sig = signature(wrapper)
+        assert "ctx" in sig.parameters
+        assert "name" in sig.parameters

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "typerdrive"
-version = "0.9.6"
+version = "0.9.7"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
…t Python 3.14 lazy __annotate__ NameError

- Add TestSignatureRewriterApply test class with four new tests for apply()
- Verify apply() sets __signature__ correctly on the wrapper function
- Verify __annotations__ is a plain resolved dict after apply(), not a lazy closure
- Verify __annotations__ reflects cloaked overrides alongside unmodified params
- Add test_apply__survives_poisoned_annotate: poisons __annotate__ with a NameError to simulate Python 3.14 lazy evaluation failure, confirms inspect.signature() succeeds after apply()
- Migrate test_build__preserves_annotation_from_inner_decorator to use inner_rewriter.apply() instead of direct __signature__ assignment